### PR TITLE
Prototype updates to support running all required devMode actions on a terminal

### DIFF
--- a/.project
+++ b/.project
@@ -5,7 +5,13 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/liberty/META-INF/MANIFEST.MF
+++ b/bundles/liberty/META-INF/MANIFEST.MF
@@ -6,8 +6,9 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: liberty.tools.LibertyDevPlugin
 Export-Package: liberty.tools
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+ org.eclipse.core.expressions;bundle-version="3.8.100",
  org.eclipse.core.resources;bundle-version="3.13.700",
+ org.eclipse.core.runtime,
  org.eclipse.jdt.core;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.ui.browser;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.console;bundle-version="[3.9.0,3.12.0)"
@@ -15,6 +16,10 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: liberty
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.jem.util.emf.workbench,
+ org.eclipse.tm.internal.terminal.provisional.api,
+ org.eclipse.tm.terminal.connector.local.launcher,
  org.eclipse.tm.terminal.view.core,
  org.eclipse.tm.terminal.view.core.interfaces,
- org.eclipse.tm.terminal.view.core.interfaces.constants
+ org.eclipse.tm.terminal.view.core.interfaces.constants,
+ org.eclipse.tm.terminal.view.ui.launcher,
+ org.eclipse.tm.terminal.view.ui.manager

--- a/bundles/liberty/plugin.xml
+++ b/bundles/liberty/plugin.xml
@@ -76,4 +76,14 @@
          </run>
       </runtime>
   </extension>
+  
+  <!-- Delegate-->
+  <extension point="org.eclipse.tm.terminal.view.ui.launcherDelegates">
+      <delegate
+          class="liberty.tools.ui.terminal.LocalDevModeLauncherDelegate"
+          id="liberty.tools.ui.terminal.local.devmode.launcher.delegate"
+          label="liberty.tools.ui.terminal.local.devmode.launcher.delegate.label">
+      </delegate>
+  </extension>
+   
 </plugin>

--- a/bundles/liberty/src/liberty/tools/DevModeOperations.java
+++ b/bundles/liberty/src/liberty/tools/DevModeOperations.java
@@ -1,5 +1,6 @@
 package liberty.tools;
 
+import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -9,13 +10,24 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.dialogs.IInputValidator;
+import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalConnector;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
 import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
+import org.eclipse.tm.terminal.view.ui.manager.ConsoleManager;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 
+import liberty.tools.ui.terminal.LocalDevModeLauncherDelegate;
+import liberty.tools.ui.terminal.TerminalTabListenerImpl;
 import liberty.tools.utils.Dialog;
 import liberty.tools.utils.Project;
 
@@ -23,6 +35,7 @@ import liberty.tools.utils.Project;
  * Provides the implementation of all supported dev mode operations.
  */
 public class DevModeOperations {
+
     // TODO: Dashboard display: Handle the case where the project is configured to be built/run by both
     // Gradle and Maven at the same time.
 
@@ -42,6 +55,11 @@ public class DevModeOperations {
         IProject project = Project.getSelected();
         String projectName = project.getName();
 
+        // Check if the application has already been started.
+        if (isStarted(projectName)) {
+            return;
+        }
+
         try {
             // Get the absolute path to the application project.
             String projectPath = Project.getPath(project);
@@ -53,8 +71,9 @@ public class DevModeOperations {
             String cmd = "";
             if (Project.isMaven(project)) {
                 cmd = getMavenCommand("io.openliberty.tools:liberty-maven-plugin:dev -f " + projectPath);
+
             } else if (Project.isGradle(project)) {
-                cmd = getGradleCommand("gradle libertyDev -p=" + projectPath);
+                cmd = getGradleCommand("libertyDev -p=" + projectPath);
             } else {
                 Dialog.displayErrorMessage("Project" + projectName + "is not a Gradle or Maven project.");
 
@@ -75,11 +94,23 @@ public class DevModeOperations {
      * 
      * @return An error message or null if the command was processed successfully.
      */
-    public void startWithParms(String userParms) {
+    public void startWithParms() {
         IProject project = Project.getSelected();
         String projectName = project.getName();
 
+        // Check if the application has already been started.
+        if (isStarted(projectName)) {
+            return;
+        }
+
         try {
+            // Get start parameters from the user. If the user cancelled or closed the parameter dialog,
+            // take that as indication that no action should take place.
+            String userParms = getStartParms();
+            if (userParms == null) {
+                return;
+            }
+
             // Get the absolute path to the application project.
             String projectPath = Project.getPath(project);
             if (projectPath == null) {
@@ -91,7 +122,7 @@ public class DevModeOperations {
             if (Project.isMaven(project)) {
                 cmd = getMavenCommand("io.openliberty.tools:liberty-maven-plugin:dev " + userParms + " -f " + projectPath);
             } else if (Project.isGradle(project)) {
-                cmd = getGradleCommand("gradle libertyDev " + userParms + " -p=" + projectPath);
+                cmd = getGradleCommand("libertyDev " + userParms + " -p=" + projectPath);
             } else {
                 Dialog.displayErrorMessage("Project" + projectName + "is not a Gradle or Maven project.");
                 return;
@@ -115,6 +146,11 @@ public class DevModeOperations {
         IProject project = Project.getSelected();
         String projectName = project.getName();
 
+        // Check if the application has already been started.
+        if (isStarted(projectName)) {
+            return;
+        }
+
         try {
             // Get the absolute path to the application project.
             String projectPath = Project.getPath(project);
@@ -127,7 +163,7 @@ public class DevModeOperations {
             if (Project.isMaven(project)) {
                 cmd = getMavenCommand("io.openliberty.tools:liberty-maven-plugin:devc -f " + projectPath);
             } else if (Project.isGradle(project)) {
-                cmd = getGradleCommand("gradle libertyDevc -p=" + projectPath);
+                cmd = getGradleCommand("libertyDevc -p=" + projectPath);
             } else {
                 Dialog.displayErrorMessage("Project" + projectName + "is not a Gradle or Maven project.");
             }
@@ -151,10 +187,31 @@ public class DevModeOperations {
         String projectName = project.getName();
 
         try {
-            String cmd = "q";
-            runCommand(cmd, projectName);
+            // Validate that we can get to the respective terminal's output stream.
+            LocalDevModeLauncherDelegate delegate = LocalDevModeLauncherDelegate.getInstance();
+            if (delegate == null) {
+                throw new Exception("Unable to find the development mode launcher delegate. Be sure to run the start action first.");
+            }
+
+            ITerminalConnector terminalConnector = delegate.getConnector(projectName);
+            if (terminalConnector == null) {
+                throw new Exception(
+                        "Unable to find terminal connector. Be sure to run the start action first. Note that attempting to stop orphaned processes with this action in not valid. Orphaned processes require manual intervention.");
+            }
+
+            OutputStream terminalStream = terminalConnector.getTerminalToRemoteStream();
+            if (terminalStream == null) {
+                throw new Exception(
+                        "Unable to find terminal remote stream. The terminal might not be active. Be sure to run the start action first.  Note that attempting to stop orphaned processes with this action in not valid. Orphaned processes require manual intervention.");
+            }
+
+            // Prepare the development mode command to stop the server.
+            String cmd = "exit" + System.lineSeparator();
+
+            // Issue the command on the terminal.
+            terminalStream.write(cmd.getBytes());
         } catch (Exception e) {
-            Dialog.displayErrorMessageWithDetails("An error was detected while performing the stop action.", e);
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the stop action on project " + projectName, e);
             return;
         }
     }
@@ -167,11 +224,33 @@ public class DevModeOperations {
     public void runTests() {
         IProject project = Project.getSelected();
         String projectName = project.getName();
-        String cmd = " ";
+
         try {
-            runCommand(cmd, projectName);
+            // Validate that we can get to the respective terminal's output stream.
+            LocalDevModeLauncherDelegate delegate = LocalDevModeLauncherDelegate.getInstance();
+            if (delegate == null) {
+                throw new Exception("Unable to find the development mode launcher delegate. Be sure to run the start action first.");
+            }
+
+            ITerminalConnector terminalConnector = delegate.getConnector(projectName);
+            if (terminalConnector == null) {
+                throw new Exception("Unable to find terminal connector. Be sure to run the start action first.");
+            }
+
+            OutputStream terminalStream = terminalConnector.getTerminalToRemoteStream();
+            if (terminalStream == null) {
+                throw new Exception(
+                        "Unable to find terminal remote stream. The terminal might not be active. Be sure to run the start action first.");
+            }
+
+            // Prepare the development mode command to run a test.
+            String cmd = System.lineSeparator();
+
+            // Issue the command on the terminal
+            terminalStream.write(cmd.getBytes());
         } catch (Exception e) {
-            Dialog.displayErrorMessageWithDetails("An error was detected while performing the run tests action.", e);
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the run tests action on project " + projectName,
+                    e);
             return;
         }
     }
@@ -309,7 +388,7 @@ public class DevModeOperations {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(ITerminalsConnectorConstants.PROP_TITLE, projectName);
         properties.put(ITerminalsConnectorConstants.PROP_ENCODING, "UTF-8");
-        properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID, "org.eclipse.tm.terminal.connector.local.launcher.local");
+        properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID, LocalDevModeLauncherDelegate.id);
         properties.put(ITerminalsConnectorConstants.PROP_PROCESS_ARGS, cmd);
         properties.put(ITerminalsConnectorConstants.PROP_DATA, projectName);
         properties.put(ITerminalsConnectorConstants.PROP_PROCESS_ENVIRONMENT, envs.toArray(new String[envs.size()]));
@@ -318,7 +397,62 @@ public class DevModeOperations {
         properties.put(ITerminalsConnectorConstants.PROP_DATA_NO_RECONNECT, Boolean.TRUE);
 
         ITerminalService ts = TerminalServiceFactory.getService();
-        ts.openConsole(properties, null);
+
+        ITerminalService.Done done = new ITerminalService.Done() {
+            @Override
+            public void done(IStatus status) {
+                if (status.getCode() == IStatus.OK) {
+                    TerminalTabListenerImpl tabListener = new TerminalTabListenerImpl(ts, projectName);
+                    ts.addTerminalTabListener(tabListener);
+                }
+            }
+        };
+
+        ts.openConsole(properties, done);
+    }
+
+    /**
+     * Returns the list of parameters if the user presses OK, null otherwise.
+     * 
+     * @return The list of parameters if the user presses OK, null otherwise.
+     */
+    public String getStartParms() {
+        String dTitle = "Liberty Development Mode";
+        String dMessage = "Specify custom parameters for the liberty dev command.";
+        String dInitValue = "";
+        IInputValidator iValidator = getParmListValidator();
+        Shell shell = Display.getCurrent().getActiveShell();
+        InputDialog iDialog = new InputDialog(shell, dTitle, dMessage, dInitValue, iValidator) {
+        };
+
+        String userInput = null;
+
+        if (iDialog.open() == Window.OK) {
+            userInput = iDialog.getValue().trim();
+        }
+
+        return userInput;
+    }
+
+    /**
+     * Creates a validation object for user provided parameters.
+     * 
+     * @return A validation object for user provided parameters.
+     */
+    public IInputValidator getParmListValidator() {
+        return new IInputValidator() {
+
+            @Override
+            public String isValid(String text) {
+                String[] parmSegments = text.split(" ");
+                for (int i = 0; i < parmSegments.length; i++) {
+                    if (parmSegments[i] != null && !parmSegments[i].isEmpty() && !parmSegments[i].startsWith("-")) {
+                        return "Parameters must start with -";
+                    }
+                }
+                return null;
+            }
+        };
     }
 
     /**
@@ -381,13 +515,13 @@ public class DevModeOperations {
     /**
      * Returns the full Maven command to run on the terminal.
      * 
-     * @param baseCommand The mvn command args
+     * @param cmdArgs The mvn command args
      * 
      * @return The full Maven command to run on the terminal.
      */
     private String getMavenCommand(String cmdArgs) {
         StringBuilder sb = new StringBuilder();
-        
+
         String baseCmd = isWindows() ? "mvn.cmd" : "mvn";
         String mvnCmd = null;
 
@@ -399,30 +533,43 @@ public class DevModeOperations {
         }
 
         sb.append(mvnCmd).append(" ").append(cmdArgs);
-        
+
         if (isWindows()) {
             // Include trailing space for separation
             sb.insert(0, "/c ");
-        } 
-        
+        }
+
         return sb.toString();
     }
 
     /**
      * Returns the full Gradle command to run on the terminal.
      * 
-     * @param baseCommand The base development mode command.
+     * @param cmdArgs The Gradle command args.
      * 
      * @return The full Gradle command to run on the terminal.
      */
-    private String getGradleCommand(String baseCommand) {
-        StringBuilder cmd = new StringBuilder(baseCommand);
+    private String getGradleCommand(String cmdArgs) {
+        StringBuilder sb = new StringBuilder();
+
+        String baseCmd = isWindows() ? "gradle.bat" : "gradle";
+        String gradleCmd = null;
+
         String gradleInstallPath = getGradleInstallHome();
         if (gradleInstallPath != null) {
-            return Paths.get(gradleInstallPath, "bin", cmd.toString()).toString();
+            gradleCmd = Paths.get(gradleInstallPath, "bin", baseCmd).toString();
+        } else {
+            gradleCmd = baseCmd;
         }
 
-        return cmd.insert(0, "gradle ").toString();
+        sb.append(gradleCmd).append(" ").append(cmdArgs);
+
+        if (isWindows()) {
+            // Include trailing space for separation
+            sb.insert(0, "/c ");
+        }
+
+        return sb.toString();
     }
 
     /**
@@ -440,5 +587,39 @@ public class DevModeOperations {
         Path path = Paths.get(projectPath, "build", "reports", "tests", "test", "index.html");
 
         return path;
+    }
+
+    /**
+     * Returns true if the input project has already been started. False, otherwise.
+     * 
+     * @param projectName The project name to check.
+     * 
+     * @return True if the input project has already been started. False, otherwise
+     */
+    private boolean isStarted(String projectName) {
+        // Find if there is a connector already associated with the project. If there is one, make sure
+        // that associated terminal was terminated.
+        LocalDevModeLauncherDelegate delegate = LocalDevModeLauncherDelegate.getInstance();
+        if (delegate != null) {
+            ITerminalConnector connector = delegate.getConnector(projectName);
+
+            if (connector != null) {
+                ConsoleManager consoleMgr = ConsoleManager.getInstance();
+                CTabItem item = consoleMgr.findConsole(null, null, projectName, connector, null);
+                if (item != null) {
+                    if (!item.getText().contains("<Closed>")) {
+                        Dialog.displayWarningMessage("Application project " + projectName + " is already running.");
+                        return true;
+                    } else {
+                        // There is no easy way to get notified when the terminal is disconnected, so proactively close the
+                        // terminal as it would on normal restart (PROP_FORCE_NEW=TRUE) in order to cleanup. This action
+                        // triggers the registered tab listeners to be called.
+                        item.dispose();
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/bundles/liberty/src/liberty/tools/ui/DashboardView.java
+++ b/bundles/liberty/src/liberty/tools/ui/DashboardView.java
@@ -121,7 +121,6 @@ public class DashboardView extends ViewPart {
                 Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
                 return;
             }
-            mgr.add(new Separator());
         }
     }
 
@@ -155,11 +154,7 @@ public class DashboardView extends ViewPart {
         startWithParmAction = new Action("Start...") {
             @Override
             public void run() {
-                String parms = getStartParms();
-
-                if (parms != null) {
-                    devMode.startWithParms(parms);
-                }
+                devMode.startWithParms();
             }
         };
         startWithParmAction.setImageDescriptor(ActionImg);
@@ -231,49 +226,5 @@ public class DashboardView extends ViewPart {
             }
         };
         refreshAction.setImageDescriptor(refreshImg);
-    }
-
-    /**
-     * Returns the list of parameters if the user presses OK, null otherwise.
-     * 
-     * @return The list of parameters if the user presses OK, null otherwise.
-     */
-    public String getStartParms() {
-        String dTitle = "Liberty Development Mode";
-        String dMessage = "Specify custom parameters for the liberty dev command.";
-        String dInitValue = "";
-        IInputValidator iValidator = getParmListValidator();
-        Shell shell = Display.getCurrent().getActiveShell();
-        InputDialog iDialog = new InputDialog(shell, dTitle, dMessage, dInitValue, iValidator) {
-        };
-
-        String userInput = null;
-
-        if (iDialog.open() == Window.OK) {
-            userInput = iDialog.getValue();
-        }
-
-        return userInput;
-    }
-
-    /**
-     * Creates a validation object for user provided parameters.
-     * 
-     * @return A validation object for user provided parameters.
-     */
-    public IInputValidator getParmListValidator() {
-        return new IInputValidator() {
-
-            @Override
-            public String isValid(String text) {
-                String[] parmSegments = text.split(" ");
-                for (int i = 0; i < parmSegments.length; i++) {
-                    if (parmSegments[i] != null && !parmSegments[i].isEmpty() && !parmSegments[i].startsWith("-")) {
-                        return "Parameters must start with -";
-                    }
-                }
-                return null;
-            }
-        };
     }
 }

--- a/bundles/liberty/src/liberty/tools/ui/terminal/LocalDevModeLauncherDelegate.java
+++ b/bundles/liberty/src/liberty/tools/ui/terminal/LocalDevModeLauncherDelegate.java
@@ -1,0 +1,76 @@
+package liberty.tools.ui.terminal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.tm.internal.terminal.provisional.api.ITerminalConnector;
+import org.eclipse.tm.terminal.connector.local.launcher.LocalLauncherDelegate;
+import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
+import org.eclipse.tm.terminal.view.ui.launcher.LauncherDelegateManager;
+
+/**
+ * Local launcher delegate extension.
+ */
+public class LocalDevModeLauncherDelegate extends LocalLauncherDelegate {
+
+    /**
+     * Id.
+     */
+    public static final String id = "liberty.tools.ui.terminal.local.devmode.launcher.delegate";
+
+    /**
+     * Label.
+     */
+    public static final String label = "liberty.local.devmode.launcher.delegate";
+
+    /**
+     * The set of connectors associated associated with accessed application projects.
+     */
+    private ConcurrentHashMap<String, ITerminalConnector> connectors = new ConcurrentHashMap<String, ITerminalConnector>();
+
+    /**
+     * Returns an instance of the LocalTerminalLauncherDelegate. Note that there should only be a single delegate instance
+     * being used because TerminalService.createTerminalConnector by default does not require the delegate instances to be
+     * unique. Therefore, in each case, first instance created is returned.
+     * 
+     * @return An instance of the LocalTerminalLauncherDelegate
+     */
+    public static LocalDevModeLauncherDelegate getInstance() {
+        return (LocalDevModeLauncherDelegate) LauncherDelegateManager.getInstance().getLauncherDelegate(id, false);
+    }
+
+    /**
+     * Returns an instance of the local terminal connector associated with the specified project.
+     * 
+     * @return An instance of the local terminal connector associated with the specified project, or null if the connector
+     *     was not found.
+     */
+    public ITerminalConnector getConnector(String projectName) {
+        return connectors.get(projectName);
+    }
+
+    /**
+     * Removes the connector associated with the specified project.
+     * 
+     * @return The removed connector associated with the specified project, or null if the connector was not found.
+     */
+    public ITerminalConnector removeConnector(String projectName) {
+        return connectors.remove(projectName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ITerminalConnector createTerminalConnector(Map<String, Object> properties) {
+        String projectName = (String) properties.get(ITerminalsConnectorConstants.PROP_DATA);
+        ITerminalConnector connector = connectors.get(projectName);
+
+        if (connector == null) {
+            connector = super.createTerminalConnector(properties);
+            connectors.put(projectName, connector);
+        }
+
+        return connector;
+    }
+}

--- a/bundles/liberty/src/liberty/tools/ui/terminal/TerminalTabListenerImpl.java
+++ b/bundles/liberty/src/liberty/tools/ui/terminal/TerminalTabListenerImpl.java
@@ -1,0 +1,43 @@
+package liberty.tools.ui.terminal;
+
+import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
+import org.eclipse.tm.terminal.view.core.interfaces.ITerminalTabListener;
+
+/**
+ * Listens for terminal tab termination.
+ */
+public class TerminalTabListenerImpl implements ITerminalTabListener {
+
+    /**
+     * The terminal service instance being used to open the terminal and run a command.
+     */
+    ITerminalService terminalService;
+
+    /**
+     * The name of the project being processed.
+     */
+    String projectName;
+
+    /**
+     * Constructor.
+     * 
+     * @param terminalService The terminal service instance being used to open the terminal and run a command.
+     * @param projectName The name of the current project being processed.
+     */
+    public TerminalTabListenerImpl(ITerminalService terminalService, String projectName) {
+        this.terminalService = terminalService;
+        this.projectName = projectName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void terminalTabDisposed(Object source, Object data) {
+        // Cleanup the connector from our cache.
+        LocalDevModeLauncherDelegate.getInstance().removeConnector(projectName);
+
+        // Remove this listener from the service calling this listener.
+        terminalService.removeTerminalTabListener(this);
+    }
+}


### PR DESCRIPTION
This is a prototype that allows Liberty devMode commands run on a terminal.
Note that this implementation requires the use/reference of an Eclipse API that has been marked as internal and experimental. An Eclipse forum query about the API use is pending an answer.